### PR TITLE
Improve [histograms store]: send histograms(bins) stats into elasticsearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The field _indexPrefix_ is used as the prefix for your dynamic indices: for exam
 
 The type configuration options allow you to specify different elasticsearch _types for each statsd measurement.
 
-To configure Elasticsearch to automatically apply index template settings based on a naming pattern look at the es-index-template.sh file.  It will probably need customization (the timer_data type) for your particular statsd configuration (re: threshold pct).
+To configure Elasticsearch to automatically apply index template settings based on a naming pattern look at the es-index-template.sh file.  It will probably need customization (the timer_data type) for your particular statsd configuration (re: threshold pct and bins).
 
 ## Metric Name Mapping
 

--- a/es-index-template.sh
+++ b/es-index-template.sh
@@ -122,6 +122,22 @@ curl -XPUT localhost:9200/_template/statsd-template -d '
                     "type": "float",
                     "index": "not_analyzed"
                 },
+                "bin_100": {
+                    "type": "integer",
+                    "index": "not_analyzed"
+                },
+                "bin_500": {
+                    "type": "integer",
+                    "index": "not_analyzed"
+                },
+                "bin_1000": {
+                    "type": "integer",
+                    "index": "not_analyzed"
+                },
+                "bin_inf": {
+                    "type": "integer",
+                    "index": "not_analyzed"
+                },
                 "ns": {
                     "type": "string",
                     "index": "not_analyzed"

--- a/lib/elasticsearch.js
+++ b/lib/elasticsearch.js
@@ -154,6 +154,12 @@ var flush_stats = function elastic_flush(ts, metrics) {
     value["grp"] = listKeys[1] || '';
     value["tgt"] = listKeys[2] || '';
     value["act"] = listKeys[3] || '';
+    if (value['histogram']) {
+      for (var keyH in value['histogram']) {
+        value[keyH] = value['histogram'][keyH];
+      }
+      delete value['histogram'];
+    }
     array_timer_data.push(value);
     numStats += 1;
   }


### PR DESCRIPTION
Send to Elasticsearch histograms stats (https://github.com/etsy/statsd/blob/master/docs/metric_types.md) if defined.
