### PR TITLE
Improve [proxy support]: correct work when ES is on behind proxy (nginx)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,26 @@ Add a structure to your configuration called "elasticsearch"
  elasticsearch: {
 	 port:          9200,
 	 host:          "localhost",
+	 path:          "/",
 	 indexPrefix:   "statsd",
 	 countType:     "counter",
 	 timerType:     "timer",
 	 timerDataType: "timer_data"
  }
+```
+
+The field _path_ is equal to "/" if you directly connect to ES. 
+But when ES is on behind the proxy (nginx,haproxy), for example http://domain.com/elastic-proxy/, then following settings required:
+```
+    port: 80,
+    host: "domain.com",
+    path: "/elastic-proxy/",
+```
+Nginx config proxy example:
+```
+    location /elastic-proxy/ {
+        proxy_pass http://localhost:9200/;
+    }
 ```
 
 The field _indexPrefix_ is used as the prefix for your dynamic indices: for example "statsd-2014.02.04"

--- a/lib/elasticsearch.js
+++ b/lib/elasticsearch.js
@@ -13,6 +13,7 @@
  *
  *   host:          hostname or IP of ElasticSearch server
  *   port:          port of Elastic Search Server
+ *   path:          http path of Elastic Search Server (default: '/')
  *   indexPrefix:   Prefix of the dynamic index to be created (default: 'statsd')
  *   indexType:     The dociment type of the saved stat (default: 'stat')
  */
@@ -25,6 +26,7 @@ var debug;
 var flushInterval;
 var elasticHost;
 var elasticPort;
+var elasticPath;
 var elasticIndex;
 var elasticCountType;
 var elasticTimerType;
@@ -45,23 +47,6 @@ var es_bulk_insert = function elasticsearch_bulk_insert(listCounters, listTimers
       }
 
       var statsdIndex = elasticIndex + '-' + indexDate.getUTCFullYear() + '.' + indexMo + '.' +  indexDt;
-      var optionsPost = {
-        host: elasticHost,
-        port: elasticPort,
-        path: '/' + statsdIndex + '/' + '/_bulk',
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json'
-        }
-      };
-      var req = http.request(optionsPost, function(res) {
-          res.on('data', function(d) {
-            if (Math.floor(res.statusCode / 100) == 5){
-              var errdata = "HTTP " + res.statusCode + ": " + d;
-              console.log(errdata);
-            }
-          });
-      });
       var payload = '';
       for (key in listCounters) {
         payload += '{"index":{"_index":"'+statsdIndex+'","_type":"'+elasticCountType+'"}}'+"\n";
@@ -93,6 +78,25 @@ var es_bulk_insert = function elasticsearch_bulk_insert(listCounters, listTimers
           }
         payload += innerPayload +'}'+"\n";
       }
+
+      var optionsPost = {
+        host: elasticHost,
+        port: elasticPort,
+        path: elasticPath + statsdIndex + '/' + '/_bulk',
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': payload.length
+        }
+      };
+      var req = http.request(optionsPost, function(res) {
+          res.on('data', function(d) {
+            if (Math.floor(res.statusCode / 100) == 5){
+              var errdata = "HTTP " + res.statusCode + ": " + d;
+              console.log(errdata);
+            }
+          });
+      });
 
       if (debug) {
         console.log(payload);
@@ -192,6 +196,7 @@ exports.init = function elasticsearch_init(startup_time, config, events) {
 
   elasticHost      = configEs.host           || 'localhost';
   elasticPort      = configEs.port           || 9200;
+  elasticPath      = configEs.path           || '/';
   elasticIndex     = configEs.indexPrefix    || 'statsd';
   elasticCountType = configEs.countType      || 'counter';
   elasticTimerType = configEs.timerType      || 'timer';


### PR DESCRIPTION
When Elasticsearch is placed on behind the nginx server, then nginx return 411 error, because Content-Length header is required. Similar problem: https://github.com/elasticsearch/elasticsearch-py/issues/70

Example.
ES url http://domain.com/elastic-proxy/
Nginx config:

```
location /elastic-proxy/ {
       proxy_pass http://localhost:9200/;
}
```

Аdditionally _path_ parameter has been added, because ES behind proxy may be accessible not by "/" url, but with custom preffix.

Thx for this backend, very helpful.
