### PR TITLE
Update to clarify the need for an entry in the backend field.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Add a structure to your configuration called "elasticsearch"
 
 ```js
 
+ backends: [ 'statsd-elasticsearch-backend', 'other-backends'],
  elasticsearch: {
 	 port:          9200,
 	 host:          "localhost",


### PR DESCRIPTION
Took me a while to figure out that the `backends` field needed to have ElasticSearch added, and what the name to add was.
