### PR TITLE
Configurable timestamping

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Add a structure to your configuration called "elasticsearch"
 	 host:          "localhost",
 	 path:          "/",
 	 indexPrefix:   "statsd",
+	 indexTimestamp: "year",
 	 countType:     "counter",
 	 timerType:     "timer",
 	 timerDataType: "timer_data"
@@ -58,6 +59,8 @@ Nginx config proxy example:
 ```
 
 The field _indexPrefix_ is used as the prefix for your dynamic indices: for example "statsd-2014.02.04"
+
+The field _indexTimestamp_ allows you to determine the timestamping for your dynamic index. "year", "month" and "day" would produce "statsd-2014", "statsd-2014.02", "statsd-2014.02.04" respectively.
 
 The type configuration options allow you to specify different elasticsearch _types for each statsd measurement.
 

--- a/lib/elasticsearch.js
+++ b/lib/elasticsearch.js
@@ -11,11 +11,12 @@
  *
  * This backend supports the following config options:
  *
- *   host:          hostname or IP of ElasticSearch server
- *   port:          port of Elastic Search Server
- *   path:          http path of Elastic Search Server (default: '/')
- *   indexPrefix:   Prefix of the dynamic index to be created (default: 'statsd')
- *   indexType:     The dociment type of the saved stat (default: 'stat')
+ *   host:            hostname or IP of ElasticSearch server
+ *   port:            port of Elastic Search Server
+ *   path:            http path of Elastic Search Server (default: '/')
+ *   indexPrefix:     Prefix of the dynamic index to be created (default: 'statsd')
+ *   indexTimestamp:  Timestamping format of the index, either "year", "month" or "day"
+ *   indexType:       The dociment type of the saved stat (default: 'stat')
  */
 
 var net = require('net'),
@@ -28,6 +29,7 @@ var elasticHost;
 var elasticPort;
 var elasticPath;
 var elasticIndex;
+var elasticIndexTimestamp;
 var elasticCountType;
 var elasticTimerType;
 
@@ -37,16 +39,25 @@ var elasticStats = {};
 var es_bulk_insert = function elasticsearch_bulk_insert(listCounters, listTimers, listTimerData) {
 
       var indexDate = new Date();
-      var indexMo = indexDate.getUTCMonth() +1;
-      if (indexMo < 10) {
-          indexMo = '0'+indexMo;
-      }
-      var indexDt = indexDate.getUTCDate();
-      if (indexDt < 10) {
-          indexDt = '0'+indexDt;
+
+      var statsdIndex = elasticIndex + '-' + indexDate.getUTCFullYear()
+
+      if (elasticIndexTimestamp == 'month' || elasticIndexTimestamp == 'day'){
+        var indexMo = indexDate.getUTCMonth() +1;
+        if (indexMo < 10) {
+            indexMo = '0'+indexMo;
+        }
+        statsdIndex += '.' + indexMo;
       }
 
-      var statsdIndex = elasticIndex + '-' + indexDate.getUTCFullYear() + '.' + indexMo + '.' +  indexDt;
+      if (elasticIndexTimestamp == 'day'){
+        var indexDt = indexDate.getUTCDate();
+        if (indexDt < 10) {
+            indexDt = '0'+indexDt;
+        }
+        statsdIndex += '.' +  indexDt;
+      }
+
       var payload = '';
       for (key in listCounters) {
         payload += '{"index":{"_index":"'+statsdIndex+'","_type":"'+elasticCountType+'"}}'+"\n";
@@ -198,6 +209,7 @@ exports.init = function elasticsearch_init(startup_time, config, events) {
   elasticPort      = configEs.port           || 9200;
   elasticPath      = configEs.path           || '/';
   elasticIndex     = configEs.indexPrefix    || 'statsd';
+  elasticIndexTimestamp = configEs.indexTimestamp || 'day';
   elasticCountType = configEs.countType      || 'counter';
   elasticTimerType = configEs.timerType      || 'timer';
   elasticTimerType = configEs.timerDataType  || 'timer_data';


### PR DESCRIPTION
My two cents. Sometimes it's nice to have monthly or yearly timestamps.

The config field ``indexTimestamp`` allows you to determine the timestamping for your dynamic index. "year", "month" and "day" would produce "statsd-2014", "statsd-2014.02", "statsd-2014.02.04" respectively. Default is "day".