### PR TITLE
Fix mapping confusion, and support act field when list key has more than three elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Add a structure to your configuration called "elasticsearch"
 	 //indexTimestamp: "month", //for index statsd-2015.01
 	 indexTimestamp: "day",     //for index statsd-2015.01.01
 	 countType:     "counter",
+	 timerType:     "timer",
 	 timerDataType: "timer_data"
  }
 ```

--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ Add a structure to your configuration called "elasticsearch"
 	 //indexTimestamp: "month", //for index statsd-2015.01
 	 indexTimestamp: "day",     //for index statsd-2015.01.01
 	 countType:     "counter",
-	 timerType:     "timer",
 	 timerDataType: "timer_data"
  }
 ```

--- a/es-index-template.sh
+++ b/es-index-template.sh
@@ -34,7 +34,7 @@ curl -XPUT localhost:9200/_template/statsd-template -d '
                 }
             }
         },
-        "timer" : {
+        "timer_data" : {
             "_source" : { "enabled" : true },
             "properties": {
                 "@timestamp": {
@@ -63,7 +63,7 @@ curl -XPUT localhost:9200/_template/statsd-template -d '
                 }
             }
         },
-        "timer_data" : {
+        "timer_data_stats" : {
             "_source" : { "enabled" : true },
             "properties": {
                 "@timestamp": {

--- a/lib/elasticsearch.js
+++ b/lib/elasticsearch.js
@@ -139,7 +139,7 @@ var flush_stats = function elastic_flush(ts, metrics) {
   for (key in metrics.counters) {
     var listKeys = key.split('.');
     var value = metrics.counters[key];
-    var act = listKeys.slice(3, listKeys.length).join('-');
+    var act = listKeys.slice(3, listKeys.length).join('.');
     array_counts.push({
 		"ns": listKeys[0] || '',
 		"grp":listKeys[1] || '',
@@ -155,7 +155,7 @@ var flush_stats = function elastic_flush(ts, metrics) {
   for (key in metrics.timers) {
     var listKeys = key.split('.');
     var series = metrics.timers[key];
-    var act = listKeys.slice(3, listKeys.length).join('-');
+    var act = listKeys.slice(3, listKeys.length).join('.');
     for (keyTimer in series) {
       array_timers.push({
 		"ns": listKeys[0] || '',
@@ -171,7 +171,7 @@ var flush_stats = function elastic_flush(ts, metrics) {
   for (key in metrics.timer_data) {
     var listKeys = key.split('.');
     var value = metrics.timer_data[key];
-    var act = listKeys.slice(3, listKeys.length).join('-');
+    var act = listKeys.slice(3, listKeys.length).join('.');
     value["@timestamp"] = ts;
     value["ns"]  = listKeys[0] || '';
     value["grp"] = listKeys[1] || '';

--- a/lib/elasticsearch.js
+++ b/lib/elasticsearch.js
@@ -139,11 +139,12 @@ var flush_stats = function elastic_flush(ts, metrics) {
   for (key in metrics.counters) {
     var listKeys = key.split('.');
     var value = metrics.counters[key];
+    var act = listKeys.slice(3, listKeys.length).join('-');
     array_counts.push({
 		"ns": listKeys[0] || '',
 		"grp":listKeys[1] || '',
 		"tgt":listKeys[2] || '',
-		"act":listKeys[3] || '',
+		"act":act || '',
 		"val":value,
 		"@timestamp": ts
 	});
@@ -154,12 +155,13 @@ var flush_stats = function elastic_flush(ts, metrics) {
   for (key in metrics.timers) {
     var listKeys = key.split('.');
     var series = metrics.timers[key];
+    var act = listKeys.slice(3, listKeys.length).join('-');
     for (keyTimer in series) {
       array_timers.push({
 		"ns": listKeys[0] || '',
 		"grp":listKeys[1] || '',
 		"tgt":listKeys[2] || '',
-		"act":listKeys[3] || '',
+		"act":act || '',
 		"val":series[keyTimer],
 		"@timestamp": ts
 	});
@@ -169,11 +171,12 @@ var flush_stats = function elastic_flush(ts, metrics) {
   for (key in metrics.timer_data) {
     var listKeys = key.split('.');
     var value = metrics.timer_data[key];
+    var act = listKeys.slice(3, listKeys.length).join('-');
     value["@timestamp"] = ts;
     value["ns"]  = listKeys[0] || '';
     value["grp"] = listKeys[1] || '';
     value["tgt"] = listKeys[2] || '';
-    value["act"] = listKeys[3] || '';
+    value["act"] = act || '';
     if (value['histogram']) {
       for (var keyH in value['histogram']) {
         value[keyH] = value['histogram'][keyH];
@@ -220,7 +223,6 @@ exports.init = function elasticsearch_init(startup_time, config, events, logger)
   elasticIndex     = configEs.indexPrefix    || 'statsd';
   elasticIndexTimestamp = configEs.indexTimestamp || 'day';
   elasticCountType = configEs.countType      || 'counter';
-  elasticTimerType = configEs.timerType      || 'timer';
   elasticTimerType = configEs.timerDataType  || 'timer_data';
   flushInterval    = config.flushInterval;
 


### PR DESCRIPTION
The es mapping script does not reflect the code that inserts data, and the `act` field in the documents does not take into consideration keys that have more than three elements (dots). This commit is an attemtp to fix this.