### PR TITLE
Regex key parsing

### DIFF
--- a/lib/elasticsearch.js
+++ b/lib/elasticsearch.js
@@ -20,11 +20,14 @@
  */
 
 var net = require('net'),
-   util = require('util'),
-   http = require('http');
+    util = require('util'),
+    http = require('http'),
+    named = require('named-regexp').named,
+    extend = require('util')._extend;
 // this will be instantiated to the logger
 var lg;
 var debug;
+var keyRegex;
 var flushInterval;
 var elasticHost;
 var elasticPort;
@@ -134,46 +137,43 @@ var flush_stats = function elastic_flush(ts, metrics) {
 /*
   var gauges = metrics.gauges;
   var pctThreshold = metrics.pctThreshold;
-*/
+ */
+
+  var matched;
 
   for (key in metrics.counters) {
-    var listKeys = key.split('.');
-    var value = metrics.counters[key];
-    array_counts.push({
-		"ns": listKeys[0] || '',
-		"grp":listKeys[1] || '',
-		"tgt":listKeys[2] || '',
-		"act":listKeys[3] || '',
-		"val":value,
-		"@timestamp": ts
-	});
+    matched = keyRegex.exec(key);
+    if (matched === null) continue;
+
+    array_counts.push(extend(matched.captures, {
+      "val": metrics.counters[key],
+      "@timestamp": ts
+    }));
 
     numStats += 1;
   }
 
   for (key in metrics.timers) {
-    var listKeys = key.split('.');
+    matched = keyRegex.exec(key);
+    if (matched === null) continue;
+
     var series = metrics.timers[key];
     for (keyTimer in series) {
-      array_timers.push({
-		"ns": listKeys[0] || '',
-		"grp":listKeys[1] || '',
-		"tgt":listKeys[2] || '',
-		"act":listKeys[3] || '',
-		"val":series[keyTimer],
-		"@timestamp": ts
-	});
+      array_timers.push(extend({
+        "val": series[keyTimer],
+        "@timestamp": ts
+      }, matched.captures));
     }
   }
 
   for (key in metrics.timer_data) {
-    var listKeys = key.split('.');
-    var value = metrics.timer_data[key];
+    matched = keyRegex.exec(key);
+    if (matched === null) continue;
+
+    var value = extend(metrics.timer_data[key], matched.captures);
+
     value["@timestamp"] = ts;
-    value["ns"]  = listKeys[0] || '';
-    value["grp"] = listKeys[1] || '';
-    value["tgt"] = listKeys[2] || '';
-    value["act"] = listKeys[3] || '';
+
     if (value['histogram']) {
       for (var keyH in value['histogram']) {
         value[keyH] = value['histogram'][keyH];
@@ -214,6 +214,9 @@ exports.init = function elasticsearch_init(startup_time, config, events, logger)
 
   var configEs = config.elasticsearch || { };
 
+  // To include everything after the third dot in act use:
+  // named(/^(:<ns>[^.]+)\.(:<grp>[^.]+)\.(:<tgt>[^.]+)(?:\.(:<act>.+))?/)
+  keyRegex              = configEs.keyRegex       || named(/^(:<ns>[^.]+)\.(:<grp>[^.]+)\.(:<tgt>[^.]+)(?:\.(:<act>[^.]+))?/);  
   elasticHost           = configEs.host           || 'localhost';
   elasticPort           = configEs.port           || 9200;
   elasticPath           = configEs.path           || '/';

--- a/lib/elasticsearch.js
+++ b/lib/elasticsearch.js
@@ -215,16 +215,16 @@ exports.init = function elasticsearch_init(startup_time, config, events, logger)
   var configEs = config.elasticsearch || { };
 
   // To include everything after the third dot in act use:
-  // named(/^(:<ns>[^.]+)\.(:<grp>[^.]+)\.(:<tgt>[^.]+)(?:\.(:<act>.+))?/)
-  keyRegex              = configEs.keyRegex       || named(/^(:<ns>[^.]+)\.(:<grp>[^.]+)\.(:<tgt>[^.]+)(?:\.(:<act>[^.]+))?/);  
-  elasticHost           = configEs.host           || 'localhost';
-  elasticPort           = configEs.port           || 9200;
-  elasticPath           = configEs.path           || '/';
-  elasticIndex          = configEs.indexPrefix    || 'statsd';
-  elasticIndexTimestamp = configEs.indexTimestamp || 'day';
-  elasticCountType      = configEs.countType      || 'counter';
-  elasticTimerType      = configEs.timerType      || 'timer';
-  elasticTimerDataType  = configEs.timerDataType  || elasticTimerType + '_stats';
+  // /^(:<ns>[^.]+)\.(:<grp>[^.]+)\.(:<tgt>[^.]+)(?:\.(:<act>.+))?/
+  keyRegex              = named(configEs.keyRegex) || named(/^(:<ns>[^.]+)\.(:<grp>[^.]+)\.(:<tgt>[^.]+)(?:\.(:<act>[^.]+))?/);  
+  elasticHost           = configEs.host            || 'localhost';
+  elasticPort           = configEs.port            || 9200;
+  elasticPath           = configEs.path            || '/';
+  elasticIndex          = configEs.indexPrefix     || 'statsd';
+  elasticIndexTimestamp = configEs.indexTimestamp  || 'day';
+  elasticCountType      = configEs.countType       || 'counter';
+  elasticTimerType      = configEs.timerType       || 'timer';
+  elasticTimerDataType  = configEs.timerDataType   || elasticTimerType + '_stats';
   flushInterval         = config.flushInterval;
 
   elasticStats.last_flush = startup_time;

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
   "engines": {
     "node": ">=0.8"
   },
-  "dependencies": {},
+  "dependencies": {
+    "named-regexp": "^0.1.1"
+  },
   "devDependencies": {},
   "main": "lib/elasticsearch.js"
 }


### PR DESCRIPTION
This will allow for arbitrary structure of keys and arbitrary field names to be inserted into ElasticSearch. The default retains the current functionality, and the functionality that #15 implements can be replicated by setting keyRegex in the config to `/^(:<ns>[^.]+)\.(:<grp>[^.]+)\.(:<tgt>[^.]+)(?:\.(:<act>.+))?/`.

It uses https://www.npmjs.com/package/named-regexp to add named captures to regexes. It seems worth it to add the dependency to get the configurability of key parsing with so little effort.

In my use case, I have weird legacy keys in the form

`appname.type.impressions.0.0.0.0.1.12345.count`,

so I am using a regex like

`/^(:<app>[^.]+)\.(:<data_type>[^.]+)\.(:<view_type>[^.]+)\.\d\.\d\.\d\.\d\.\d\.(:<data_id>\d+)\.(:<stat_type>[^.]+)/`.

 It's kind of verbose, but it's understandable and does the job.