### PR TITLE
remove dateOptionalTime format so ES2.0 doesn't error on epoch_millis…

### DIFF
--- a/es-index-template.sh
+++ b/es-index-template.sh
@@ -9,7 +9,6 @@ curl -XPUT localhost:9200/_template/statsd-template -d '
             "_source" : { "enabled" : true },
             "properties": {
                 "@timestamp": {
-                    "format": "dateOptionalTime",
                     "type": "date"
                 },
                 "val": {
@@ -38,7 +37,6 @@ curl -XPUT localhost:9200/_template/statsd-template -d '
             "_source" : { "enabled" : true },
             "properties": {
                 "@timestamp": {
-                    "format": "dateOptionalTime",
                     "type": "date"
                 },
                 "val": {
@@ -67,7 +65,6 @@ curl -XPUT localhost:9200/_template/statsd-template -d '
             "_source" : { "enabled" : true },
             "properties": {
                 "@timestamp": {
-                    "format": "dateOptionalTime",
                     "type": "date"
                 },
                 "val": {
@@ -96,7 +93,6 @@ curl -XPUT localhost:9200/_template/statsd-template -d '
             "_source" : { "enabled" : true },
             "properties": {
                 "@timestamp": {
-                    "format": "dateOptionalTime",
                     "type": "date"
                 },
                 "count_ps": {


### PR DESCRIPTION
@timestamp had a hardcoded "dateOptionalTime" format in es-index-template, this makes ES2.0 reject all epoch_millis timestamps as errors.

Removed the date format from es-index-template so both ES1.7 and ES2.0 will accept epoch_millis timestamps.

dateOptionalTime is already the default formatter in ES1.7 so removing this entry doesn't affect it. 