### PR TITLE
Support higher precision for values

### DIFF
--- a/es-index-template.sh
+++ b/es-index-template.sh
@@ -12,7 +12,7 @@ curl -XPUT "${ES_HOST:-localhost}:${ES_PORT:-9200}/_template/statsd-template" -d
                     "type": "date"
                 },
                 "val": {
-                    "type": "long",
+                    "type": "double",
                     "index": "not_analyzed"
                 },
                 "ns": {
@@ -40,7 +40,7 @@ curl -XPUT "${ES_HOST:-localhost}:${ES_PORT:-9200}/_template/statsd-template" -d
                     "type": "date"
                 },
                 "val": {
-                    "type": "long",
+                    "type": "double",
                     "index": "not_analyzed"
                 },
                 "ns": {
@@ -68,7 +68,7 @@ curl -XPUT "${ES_HOST:-localhost}:${ES_PORT:-9200}/_template/statsd-template" -d
                     "type": "date"
                 },
                 "val": {
-                    "type": "long",
+                    "type": "double",
                     "index": "not_analyzed"
                 },
                 "ns": {


### PR DESCRIPTION
The current template is too strict to support higher precision metrics.
This commit solves this by changing the mapping type of the `val` field
of the instruments from `long` to `double`.