### PR TITLE
Update elasticsearch.js

### DIFF
--- a/lib/elasticsearch.js
+++ b/lib/elasticsearch.js
@@ -126,7 +126,7 @@ var es_bulk_insert = function elasticsearch_bulk_insert(listCounters, listTimers
         innerPayload = '';
           for (statKey in listGaugeData[key]){
             if (innerPayload) innerPayload += ',';
-            innerPayload += renderKV(statKey, listGuageData[key][statKey]);
+            innerPayload += renderKV(statKey, listGaugeData[key][statKey]);
             //innerPayload += '"'+statKey+'":"'+listGaugeData[key][statKey]+'"';
           }
         payload += innerPayload +'}'+"\n";


### PR DESCRIPTION
Bug Fix for below issue:

/opt/nodejs/6.11.0/lib/node_modules/statsd-elasticsearch-backend/lib/elasticsearch.js:129
            innerPayload += renderKV(statKey, listGuageData[key][statKey]);
                                              ^
 
ReferenceError: listGuageData is not defined
    at elasticsearch_bulk_insert (/opt/nodejs/6.11.0/lib/node_modules/statsd-elasticsearch-backend/lib/elasticsearch.js:129:47)
    at EventEmitter.elastic_flush (/opt/nodejs/6.11.0/lib/node_modules/statsd-elasticsearch-backend/lib/elasticsearch.js:208:3)
    at emitTwo (events.js:111:20)
    at EventEmitter.emit (events.js:191:7)
    at emitFlush (/opt/nodejs/6.11.0/lib/node_modules/statsd/stats.js:152:19)
    at Object.process_metrics (/opt/nodejs/6.11.0/lib/node_modules/statsd/lib/process_metrics.js:144:5)
    at Timeout.flushMetrics [as _onTimeout] (/opt/nodejs/6.11.0/lib/node_modules/statsd/stats.js:151:6)
    at ontimeout (timers.js:386:14)
    at tryOnTimeout (timers.js:250:5)
    at Timer.listOnTimeout (timers.js:214:5)